### PR TITLE
Should it exit after the job is done?

### DIFF
--- a/bin/workers-preview.js
+++ b/bin/workers-preview.js
@@ -29,7 +29,7 @@ main()
 function main() {
   const req = request(options.request, res => {
     readJSONFromResponse(res).then(body => {
-      opn(`https://${options.request.hostname}/#${body.id}:${options.previewUrl}`)
+      opn(`https://${options.request.hostname}/#${body.id}:${options.previewUrl}`, { wait: false })
     })
   })
 


### PR DESCRIPTION
Hey there,
very useful utility, thanks!

I'm wondering if the process should exit, after the script has been uploaded and the browser opened.

Currently I have to do a triple cleanup combo of cmd+w, cmd+tab, ctrl+c while iterating on a worker script. 😄

Having the process exit would make this a bit quicker and also give way for other applications (e.g. re-uploading the script on file change).

What's your thought on this, any particular reason the process continues to run?

Cheers